### PR TITLE
Fix hang when using MATCH; deduplicate matches [#11]

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["dylib"]
 
 [target.'cfg(target_os="android")'.dependencies]
 jni = { version = "0.11.0", default-features = false }
-dictp = { git = "https://gitlab.com/savanto/dictp.rs.git", tag = "v0.3.1" }
+dictp = { git = "https://gitlab.com/savanto/dictp.rs.git", tag = "v0.3.2" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
- Fix requests never complete when using `MATCH` and getting a large number of matches
- Deduplicate matches [#11]